### PR TITLE
workflow to generate Harbour 3.2 + mingw 9.3

### DIFF
--- a/.github/workflows/hb32_mingw_0903.yml
+++ b/.github/workflows/hb32_mingw_0903.yml
@@ -1,0 +1,62 @@
+name: mingw_0903
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'mingw 9.3'
+        default: 'mingw_0903'
+        required: true
+
+jobs:
+
+  Build:
+    runs-on: windows-latest
+    steps:
+
+    - name: Load Source
+      run: |
+         c:
+         md c:\temp\comp
+         git clone https://github.com/JoseQuintas/mingw_0903 c:\temp\comp --depth 1
+
+    - name: Clean
+      uses: JoseQuintas/action-rm@v1.0.2
+      with:
+         path: c:\temp\comp\.git
+
+    - name: Clean
+      uses: JoseQuintas/action-rm@v1.0.2
+      with:
+         path: c:\temp\comp\.gitattributes
+
+    - name: Clean
+      uses: JoseQuintas/action-rm@v1.0.2
+      with:
+         path: c:\temp\comp\.github
+
+    - name: Clean
+      uses: JoseQuintas/action-rm@v1.0.2
+      with:
+         path: c:\temp\comp\.gitignore
+
+    - name: Zip
+      env:
+         PATH: c:\program files\7-zip
+      run: |
+         c:
+         cd \temp\comp
+         7z a -r c:\temp\mingw_0903.7z mingw32\
+         7z a -r c:\temp\hb32_0903.7z harbour\
+
+    - name: Save
+      uses: actions/upload-artifact@v2
+      with:
+         name: mingw_0903
+         path: c:\temp\mingw_0903.7z
+
+    - name: Save
+      uses: actions/upload-artifact@v2
+      with:
+         name: hb32_0903
+         path: c:\temp\hb32_0903.7z


### PR DESCRIPTION
First step: mingw 9.3, Harbour and upx to HMG repo use

Best option will be clone my mingw_0903, made for use with HMG.
When you clone it, I delete it from my account.

At momment, we can use this workflow to create on repository.

Important: 
An artifact has a life of max 90 days, github delete it after this, and need re-run workflow.
This is the reason to fork mingw_0903 project to HMG-Official account.
It needs to be available on HMG-Official to run it allways when needed - each 90 days

It is not for download, we will use it to test and build HMG for download.

Note: the same occurs using workflow already available on HMG, and there is no access to update them.